### PR TITLE
feat: 支援直接拖入 ZIP 檔與多工作表切換

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ not comfortable at all. So I wrote this simple app to display submissions on the
 
 Here's a
 [sample gsheet](https://docs.google.com/spreadsheets/d/13YHkHXf2MN0dhTRIV3mbOyWSLQYtwVBaMDEd-9g11v8/edit?usp=sharing),
-please download this (your) sheets as zipped-HTML format, then open index.html and drag the HTML
-format sheet into your browser.
+please download this (your) sheets as zipped-HTML format, then open index.html and drag the file
+into your browser. You can drop either the `.zip` directly or an unzipped `.html` — when the ZIP
+contains multiple worksheets a selector appears so you can switch between them.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ not comfortable at all. So I wrote this simple app to display submissions on the
 
 Here's a
 [sample gsheet](https://docs.google.com/spreadsheets/d/13YHkHXf2MN0dhTRIV3mbOyWSLQYtwVBaMDEd-9g11v8/edit?usp=sharing),
-please download this (your) sheets as zipped-HTML format, then open index.html and drag the file
+please download this (your) sheets as zipped-HTML format, then open index.htm and drag the file
 into your browser. You can drop either the `.zip` directly or an unzipped `.html` — when the ZIP
 contains multiple worksheets a selector appears so you can switch between them.
 

--- a/app.js
+++ b/app.js
@@ -392,8 +392,19 @@ function showHomeButton() {
   btnReturnToHome.style.opacity = 1;
 }
 
+var isLoadingFile = false;
+
+function finishLoading() {
+  isLoadingFile = false;
+}
+
 function loadFile(file){
   if (!file) return;
+  if (isLoadingFile) {
+    showCopyFeedback('Still loading previous file, please wait');
+    return;
+  }
+  isLoadingFile = true;
   var name = (file.name || '').toLowerCase();
   if (name.endsWith('.zip')) {
     loadZipFile(file);
@@ -406,11 +417,12 @@ function loadFile(file){
 function loadHtmlFile(file) {
   var reader = new FileReader();
   reader.addEventListener('loadend', function () {
-    if (reader.readyState !== FileReader.DONE) return;
-    if (!vm) return;
+    if (reader.readyState !== FileReader.DONE) { finishLoading(); return; }
+    if (!vm) { finishLoading(); return; }
     vm.sheets = [];
     vm.activeSheetName = '';
     applySheetToVm(parseSheetHtml(reader.result));
+    finishLoading();
   });
   reader.readAsText(file, 'UTF-8');
 }
@@ -418,12 +430,13 @@ function loadHtmlFile(file) {
 function loadZipFile(file) {
   if (!window.JSZip) {
     if (vm) vm.state = 'ERROR';
+    finishLoading();
     return;
   }
   if (vm) vm.state = 'LOADING';
   var reader = new FileReader();
   reader.addEventListener('loadend', function () {
-    if (reader.readyState !== FileReader.DONE) return;
+    if (reader.readyState !== FileReader.DONE) { finishLoading(); return; }
     JSZip.loadAsync(reader.result).then(function (zip) {
       var entries = [];
       zip.forEach(function (path, entry) {
@@ -448,7 +461,7 @@ function loadZipFile(file) {
       });
     }).catch(function () {
       if (vm) vm.state = 'ERROR';
-    });
+    }).then(finishLoading, finishLoading);
   });
   reader.readAsArrayBuffer(file);
 }

--- a/app.js
+++ b/app.js
@@ -342,6 +342,7 @@ function runApp()
         }, 15);
       },
       returnToHome() {
+        cancelLoading();
         this.sheets = [];
         this.activeSheetName = '';
         this.db = [];
@@ -387,9 +388,22 @@ function showHomeButton() {
 }
 
 var isLoadingFile = false;
+var loadToken = 0;
+var activeReader = null;
 
-function finishLoading() {
+function finishLoading(token) {
+  if (token !== loadToken) return;
   isLoadingFile = false;
+  activeReader = null;
+}
+
+function cancelLoading() {
+  if (activeReader) {
+    try { activeReader.abort(); } catch (e) {}
+  }
+  loadToken++;
+  isLoadingFile = false;
+  activeReader = null;
 }
 
 function loadFile(file){
@@ -399,39 +413,45 @@ function loadFile(file){
     return;
   }
   isLoadingFile = true;
+  var token = loadToken;
   var name = (file.name || '').toLowerCase();
   if (name.endsWith('.zip')) {
-    loadZipFile(file);
+    loadZipFile(file, token);
   } else {
-    loadHtmlFile(file);
+    loadHtmlFile(file, token);
   }
   showHomeButton();
 }
 
-function loadHtmlFile(file) {
+function loadHtmlFile(file, token) {
   var reader = new FileReader();
+  activeReader = reader;
   reader.addEventListener('loadend', function () {
-    if (reader.readyState !== FileReader.DONE) { finishLoading(); return; }
-    if (!vm) { finishLoading(); return; }
+    if (token !== loadToken) return;
+    if (reader.readyState !== FileReader.DONE) { finishLoading(token); return; }
+    if (!vm) { finishLoading(token); return; }
     vm.sheets = [];
     vm.activeSheetName = '';
     applySheetToVm(parseSheetHtml(reader.result));
-    finishLoading();
+    finishLoading(token);
   });
   reader.readAsText(file, 'UTF-8');
 }
 
-function loadZipFile(file) {
+function loadZipFile(file, token) {
   if (!window.JSZip) {
     if (vm) vm.state = 'ERROR';
-    finishLoading();
+    finishLoading(token);
     return;
   }
   if (vm) vm.state = 'LOADING';
   var reader = new FileReader();
+  activeReader = reader;
   reader.addEventListener('loadend', function () {
-    if (reader.readyState !== FileReader.DONE) { finishLoading(); return; }
+    if (token !== loadToken) return;
+    if (reader.readyState !== FileReader.DONE) { finishLoading(token); return; }
     JSZip.loadAsync(reader.result).then(function (zip) {
+      if (token !== loadToken) return;
       var entries = [];
       zip.forEach(function (path, entry) {
         if (entry.dir) return;
@@ -448,14 +468,16 @@ function loadZipFile(file) {
           return { name: e.path.replace(/\.html?$/i, ''), rawHtml: html };
         });
       })).then(function (sheets) {
+        if (token !== loadToken) return;
         if (!vm) return;
         vm.sheets = sheets;
         vm.activeSheetName = sheets[0].name;
         applySheetToVm(parseSheetHtml(sheets[0].rawHtml));
       });
     }).catch(function () {
+      if (token !== loadToken) return;
       if (vm) vm.state = 'ERROR';
-    }).then(finishLoading, finishLoading);
+    }).then(function () { finishLoading(token); }, function () { finishLoading(token); });
   });
   reader.readAsArrayBuffer(file);
 }

--- a/app.js
+++ b/app.js
@@ -310,9 +310,6 @@ function runApp()
     watch: {
       fields: function () {
         this.selectedFields = this.fields.slice();
-      },
-      db: function () {
-        this.state = 'DONE'
       }
     },
     computed: {
@@ -349,8 +346,7 @@ function runApp()
         this.activeSheetName = '';
         this.db = [];
         this.fields = [];
-        var self = this;
-        this.$nextTick(function () { self.state = 'NOFILE'; });
+        this.state = 'NOFILE';
         btnReturnToHome.style.pointerEvents = 'none';
         btnReturnToHome.style.opacity = 0;
       },
@@ -358,10 +354,7 @@ function runApp()
         var sheet = this.sheets.find(function (s) { return s.name === name; });
         if (!sheet) return;
         this.activeSheetName = name;
-        var parsed = parseSheetHtml(sheet.rawHtml);
-        if (!parsed) { this.state = 'ERROR'; return; }
-        this.fields = parsed.fields;
-        this.db = parsed.data;
+        applySheetToVm(parseSheetHtml(sheet.rawHtml));
       }
     }
   });
@@ -385,6 +378,7 @@ function applySheetToVm(parsed) {
   if (!parsed) { vm.state = 'ERROR'; return; }
   vm.fields = parsed.fields;
   vm.db = parsed.data;
+  vm.state = 'DONE';
 }
 
 function showHomeButton() {

--- a/app.js
+++ b/app.js
@@ -50,6 +50,19 @@ function getSubmitFormData(arr)
     .map(row => arrayToObject(vm.fields, row));
 }
 
+function parseSheetHtml(html) {
+  var dom = parseHTML(html);
+  var table = dom.querySelector('table');
+  if (!table) return null;
+  var arr = tableTo2DArray(table);
+  var fields = getSubmitFormHeader(arr);
+  if (!fields) return null;
+  return {
+    fields: fields,
+    data: arr.slice(3).map(function (row) { return arrayToObject(fields, row); })
+  };
+}
+
 var vm;
 var FIELD_PREF_KEY = 'copyFieldsSelection';
 
@@ -278,7 +291,9 @@ function runApp()
         db: [],
         fields: [],
         state: 'NOFILE',
-        selectedFields: []
+        selectedFields: [],
+        sheets: [],
+        activeSheetName: ''
       }
     },
     created: function () {
@@ -330,7 +345,23 @@ function runApp()
         }, 15);
       },
       returnToHome() {
-        location.reload();
+        this.sheets = [];
+        this.activeSheetName = '';
+        this.db = [];
+        this.fields = [];
+        var self = this;
+        this.$nextTick(function () { self.state = 'NOFILE'; });
+        btnReturnToHome.style.pointerEvents = 'none';
+        btnReturnToHome.style.opacity = 0;
+      },
+      switchSheet(name) {
+        var sheet = this.sheets.find(function (s) { return s.name === name; });
+        if (!sheet) return;
+        this.activeSheetName = name;
+        var parsed = parseSheetHtml(sheet.rawHtml);
+        if (!parsed) { this.state = 'ERROR'; return; }
+        this.fields = parsed.fields;
+        this.db = parsed.data;
       }
     }
   });
@@ -349,21 +380,77 @@ document.addEventListener('drop', e => { e.stopPropagation(); e.preventDefault()
 
 
 
+function applySheetToVm(parsed) {
+  if (!vm) return;
+  if (!parsed) { vm.state = 'ERROR'; return; }
+  vm.fields = parsed.fields;
+  vm.db = parsed.data;
+}
+
+function showHomeButton() {
+  btnReturnToHome.style.pointerEvents = 'all';
+  btnReturnToHome.style.opacity = 1;
+}
+
 function loadFile(file){
+  if (!file) return;
+  var name = (file.name || '').toLowerCase();
+  if (name.endsWith('.zip')) {
+    loadZipFile(file);
+  } else {
+    loadHtmlFile(file);
+  }
+  showHomeButton();
+}
+
+function loadHtmlFile(file) {
   var reader = new FileReader();
-  reader.addEventListener('loadend', e => {
-    if(reader.readyState === FileReader.DONE) {
-      if(vm) {
-        let contentDOM = parseHTML(reader.result)
-        let arr = tableTo2DArray(contentDOM.querySelector('table'));
-        vm.fields = getSubmitFormHeader(arr);
-        vm.db = getSubmitFormData(arr);
-      }
-    }
+  reader.addEventListener('loadend', function () {
+    if (reader.readyState !== FileReader.DONE) return;
+    if (!vm) return;
+    vm.sheets = [];
+    vm.activeSheetName = '';
+    applySheetToVm(parseSheetHtml(reader.result));
   });
   reader.readAsText(file, 'UTF-8');
-  btnReturnToHome.style.pointerEvents = 'all';
-  btnReturnToHome.style.opacity = 1; // The return home button only appears after loading the file
+}
+
+function loadZipFile(file) {
+  if (!window.JSZip) {
+    if (vm) vm.state = 'ERROR';
+    return;
+  }
+  if (vm) vm.state = 'LOADING';
+  var reader = new FileReader();
+  reader.addEventListener('loadend', function () {
+    if (reader.readyState !== FileReader.DONE) return;
+    JSZip.loadAsync(reader.result).then(function (zip) {
+      var entries = [];
+      zip.forEach(function (path, entry) {
+        if (entry.dir) return;
+        if (path.indexOf('/') !== -1) return; // exclude resources/ and nested paths
+        if (!/\.html?$/i.test(path)) return;
+        entries.push({ path: path, entry: entry });
+      });
+      if (entries.length === 0) {
+        if (vm) vm.state = 'ERROR';
+        return;
+      }
+      return Promise.all(entries.map(function (e) {
+        return e.entry.async('string').then(function (html) {
+          return { name: e.path.replace(/\.html?$/i, ''), rawHtml: html };
+        });
+      })).then(function (sheets) {
+        if (!vm) return;
+        vm.sheets = sheets;
+        vm.activeSheetName = sheets[0].name;
+        applySheetToVm(parseSheetHtml(sheets[0].rawHtml));
+      });
+    }).catch(function () {
+      if (vm) vm.state = 'ERROR';
+    });
+  });
+  reader.readAsArrayBuffer(file);
 }
 
 document.addEventListener('dragover', e => {

--- a/index.htm
+++ b/index.htm
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>SITCON Reviewing Tool</title>
   <script src="https://unpkg.com/vue@2.5.16/dist/vue.js" integrity="sha384-uDHwRgVGzCbHUyl2dKQHqgCAab0OIx/w9PqT3pvjaX/ZGARjKanO5mJGjmdixblb" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/jszip@3.10.1/dist/jszip.min.js" integrity="sha384-+mbV2IY1Zk/X1p/nWllGySJSUN8uMs+gUAN10Or95UBH0fpj6GfKgPmgC5EXieXG" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://unpkg.com/bootstrap@4.1.3/dist/css/bootstrap.css" integrity="sha384-2QMA5oZ3MEXJddkHyZE/e/C1bd30ZUPdzqHrsaHMP3aGDbPA9yh77XDHXC9Imxw+" crossorigin="anonymous">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -31,6 +32,14 @@
   <template id="t">
     <div class="container">
       <h1>SITCON Submissions Reviewing Tool</h1>
+
+      <section v-if="sheets.length > 1" class="sheet-switcher">
+        <label for="sheetSelect">Worksheet</label>
+        <select id="sheetSelect" :value="activeSheetName" @change="switchSheet($event.target.value)">
+          <option v-for="s in sheets" :value="s.name">{{s.name}}</option>
+        </select>
+        <span class="text-muted small">{{sheets.length}} sheets in ZIP</span>
+      </section>
 
       <section v-if="fields.length" class="config-panel">
         <div class="config-header">
@@ -65,7 +74,7 @@
         <label for="file" class="drop-container">
           <span class="drop-title">Drop the file here</span>
           or
-          <input type="file" @change="onUploadByButton" accept=".html, .htm">
+          <input type="file" @change="onUploadByButton" accept=".html, .htm, .zip">
         </label>
       </div>
       <div v-if="state === 'ERROR'">Loading failed, please drag HTML file manually.</div>

--- a/index.htm
+++ b/index.htm
@@ -69,7 +69,7 @@
       <data-view v-if="db.length > 0" v-for="data in db" :data="data" :fields="displayFields"></data-view>
       <div v-if="state === 'LOADING'">Loading...</div>
       <div v-if="state === 'NOFILE'">
-        Please drag HTML file into this window or click the button below to upload.
+        Please drag an HTML or ZIP file into this window or click the button below to upload.
         <br>
         <label for="file" class="drop-container">
           <span class="drop-title">Drop the file here</span>
@@ -77,7 +77,7 @@
           <input type="file" @change="onUploadByButton" accept=".html, .htm, .zip">
         </label>
       </div>
-      <div v-if="state === 'ERROR'">Loading failed, please drag HTML file manually.</div>
+      <div v-if="state === 'ERROR'">Loading failed. The file may be corrupted or the ZIP may not contain the expected worksheet HTML. Please try another HTML or ZIP file.</div>
       <div v-if="state === 'DONE' && db.length == 0">NO DATA</div>
       
       <div class="button-container">

--- a/style.css
+++ b/style.css
@@ -37,6 +37,41 @@ body {
   transition: background 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
 }
 
+.sheet-switcher {
+  background: #eee;
+  border-top-right-radius: 30px;
+  border-bottom-right-radius: 30px;
+  padding: 14px 20px;
+  margin-bottom: 1.2em;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  transition: background 0.25s ease-in-out;
+}
+
+.sheet-switcher label {
+  margin: 0;
+  font-weight: 600;
+  font-family: 'Poppins', 'Roboto', sans-serif;
+}
+
+.sheet-switcher select {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid #019587;
+  background: #fff;
+  color: #212121;
+  font: inherit;
+  min-width: 180px;
+  cursor: pointer;
+}
+
+.sheet-switcher select:focus {
+  outline: 2px solid #019587;
+  outline-offset: 1px;
+}
+
 .config-header {
   display: flex;
   gap: 16px;
@@ -326,6 +361,20 @@ input[type=file]::file-selector-button:hover {
   .config-panel {
     background-color: #ffffff14;
     box-shadow: none;
+  }
+
+  .sheet-switcher {
+    background-color: #ffffff14;
+  }
+
+  .sheet-switcher select {
+    background: #2b2b2b;
+    color: #fff;
+    border: 1px solid #4ec6ba;
+  }
+
+  .sheet-switcher select:focus {
+    outline: 2px solid #4ec6ba;
   }
 
   .config-meta {


### PR DESCRIPTION
## 改動

- 可直接拖入 Google Sheets 匯出的 `.zip`,免再解壓
- ZIP 內含多個工作表時,標題下方會出現切換器,可不重新載入切換 tab
- 既有的 `.html` 拖曳流程完全不變

## 技術重點

- 透過 CDN + SRI 引入 JSZip 3.10.1,無建置流程變動
- 取根目錄的 `.html`(排除 `resources/` 等子路徑),保留 ZIP 內原始工作表順序
- 切換時 `selectedFields` 重置為新工作表全欄位(不同工作表欄位幾乎不重疊,intersection 會近乎全空)
- `Return home` 改為 state reset,不再 `location.reload`

## 測試

以兩份真實匯出樣本驗證:
- 單工作表(含中文檔名 `工作表1.html`):正常載入、不顯示切換器
- 多工作表(7 個 tab 含空格檔名 `Raw Data.html`):切換器顯示、順序正確、欄位與投稿數隨切換更新
- 既有 `.html` 路徑迴歸測試:行為一致
- 損毀 / 非預期 ZIP:顯示 ERROR,不白屏

🤖 Generated with [Claude Code](https://claude.com/claude-code)