### PR TITLE
fix: trim trailing empty rows from submission data

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,13 @@ function normalizeSkipRowsValue(value) {
 }
 
 function buildSheetData(parsed, skipRows) {
-  return parsed.rows.slice(normalizeSkipRowsValue(skipRows)).map(function (row) {
+  var rows = parsed.rows.slice(normalizeSkipRowsValue(skipRows));
+  while (rows.length > 0 && rows[rows.length - 1].every(function (cell) {
+    return !cell || !cell.trim();
+  })) {
+    rows.pop();
+  }
+  return rows.map(function (row) {
     return arrayToObject(parsed.fields, row);
   });
 }


### PR DESCRIPTION
## Summary
- 在 `getSubmitFormData` 從尾端砍掉所有格子皆為空白的 row，避免 Google Sheets 匯出時尾端大量空白 row 被當成空 submission 渲染。
- 只砍尾端連續空白 row，中間夾雜的空白 row 不會影響後續資料。

## Test plan

Testcase:
https://docs.google.com/spreadsheets/d/1iLBDkNwulYT51ggS37hOcWRT3oVOAJe94FS26nKeRKE/edit?usp=sharing

在試算表的 Table 模式，底下多餘的空行也會被輸出

<img width="742" height="887" alt="image" src="https://github.com/user-attachments/assets/19162588-8af9-4e38-8d53-0f014f01bcce" />

Before：表格內幾個空行就幾筆空資料
After：後面全空白的會被刪掉


🤖 Generated with [Claude Code](https://claude.com/claude-code)